### PR TITLE
fix batch pipelines input dataset names

### DIFF
--- a/models/img-model/batch_score/pipeline/AMLBatchPipeline.yml
+++ b/models/img-model/batch_score/pipeline/AMLBatchPipeline.yml
@@ -13,7 +13,7 @@ pipeline:
             models_id:
                 - img-model:1
             input_datasets:
-                MyMinistInput:
+                img_dataset:
                     dataset_name: img_dataset
             outputs:
                 OutputData:

--- a/models/risk-model/batch_score/pipeline/AMLBatchPipeline.yml
+++ b/models/risk-model/batch_score/pipeline/AMLBatchPipeline.yml
@@ -13,7 +13,7 @@ pipeline:
             models_id:
                 - risk-model:1
             input_datasets:
-                MyMinistInput:
+                credit_dataset:
                     dataset_name: credit_dataset
             outputs:
                 OutputData:


### PR DESCRIPTION
Dataset names should be kept in sync with `RISK_MODEL_DATASET_NAME` and `IMG_MODEL_DATASET_NAME` from `mlops/recipes/common/Variables.yml`

Fixes pipeline runtime exception: `ERROR - Exception occurred while scheduling mini batches: Cannot find dataset with id "MyMinistInput" in the workspace..`